### PR TITLE
split template haskell stuff into sec-th

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist/
+.cabal-sandbox/
+cabal.sandbox.config

--- a/README
+++ b/README
@@ -3,8 +3,6 @@ Semantic Editor Combinators
 
 Semantic Editor Combinators as described by Conal Elliott
 (See: <http://conal.net/blog/posts/semantic-editor-combinators/>)
-and Template Haskell support for automatically creating semantic 
-editor combinators from Algebraic Data Types
 
 Installation
 ============
@@ -18,7 +16,6 @@ Installation
 
     # or download zip:
     wget http://github.com/urso/sec/zipball/master
-   
+
 2.) In sec-directory install using cabal:
     $ cabal install
-

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,0 @@
-
-import Distribution.Simple
-main = defaultMain

--- a/sec.cabal
+++ b/sec.cabal
@@ -1,5 +1,5 @@
 Name:                sec
-Version:             0.0.1
+Version:             0.1.0
 Description:         Semantic Editor Combinators as described by Conal Elliott
                      (See: <http://conal.net/blog/posts/semantic-editor-combinators/>)
                      and Template Haskell support for automatically creating semantic 
@@ -14,6 +14,5 @@ cabal-version:       >= 1.6
 library
   hs-source-dirs:    src
   exposed-modules:   Data.SemanticEditors
-  build-depends:     base >= 3 && < 5,
-                     template-haskell == 2.*
-
+  build-depends:     base >= 3 && < 5
+  ghc-options:       -Wall

--- a/src/Data/SemanticEditors.hs
+++ b/src/Data/SemanticEditors.hs
@@ -1,8 +1,7 @@
 
 module Data.SemanticEditors(result, first, second, each, editIf, set, argument, 
                             left, right, ioref, maybe, just, monad, bind,
-                            applicative,
-                            mkEditors, mkEditor, mkConstrTests) 
+                            applicative)
   where
 
 import Control.Applicative
@@ -10,7 +9,6 @@ import Control.Arrow (first, second, left, right)
 import Control.Monad (liftM)
 import Data.Char (toUpper)
 import Data.Maybe (isJust, fromJust, maybe)
-import Language.Haskell.TH.Syntax
 import Data.IORef
 
 -- |Semantic Editor Combinator on the result of an unary function
@@ -53,94 +51,3 @@ ioref = flip modifyIORef
 --  yields true for an input value.
 editIf :: (a -> Bool) -> (a -> a) -> (a -> a)
 editIf p f a = if p a then f a else a
-
-infix 1 <.> -- chosen arbitrarily
-f <.> g = (f <$>) . g
-
--- |mkEditors creates Semantic Editor Combinators for each data type given. 
---  More information see mkEditor
-mkEditors :: [Name] -> Q [Dec]
-mkEditors = concat <.> mapM mkEditor
-
--- |mkEditor creates Semantic Editor Combinators for each named field in a given data type by
---  appending the fields name (first letter is converted to uppercase) to the name \"edit\".
---  If a fields name starts with an underscore \'_\' no editor will be generated
---
---  for example:
---
--- >  data Person = Person { age :: Integer, name :: String, _sex :: String }
---
---  will generate the lifters  editAge and editName:
---
--- @
---    editAge  f p = p { age = f (age p) }
---    editName f p = p { name = f (name p) }
--- @
---
-mkEditor :: Name -> Q [Dec]
-mkEditor name = do
-    i <- reify name
-    map (fromJust) . filter (isJust) <.> mapM mkEditor' . concatMap vars $
-      case i of
-        TyConI (DataD _ _ _ cs _) -> cs
-        TyConI (NewtypeD _ _ _ c _) -> [c]
-        _ -> []
-
-  where vars (RecC _ v) = v
-
-mkEditor' (name, _, _) = case nameBase name of
-                           ('_':_)  -> return Nothing
-                           (c:rest) -> Just <$> mkEditor'' ("edit" ++ (toUpper c:rest))
-  where 
-    mkEditor'' :: String -> Q Dec
-    mkEditor'' name' = return $
-      FunD (mkName name')
-           [Clause [VarP (mkName "f"), VarP (mkName "r")] (NormalB $ 
-                   RecUpdE (VarE (mkName "r")) 
-                           [(name, 
-                             AppE (VarE (mkName "f")) 
-                                  (AppE (VarE name) (VarE $ mkName "r")))
-                           ]) []]
-
--- |Template Haskell function for automatically creating predicates testing the constructors of a 
---  given data type.
---  for example:
---
--- @
---   data Color = Red | Green | Blue
---  $(mkConstrTests [''Color])
--- @
-  --
---  will generate the following functions:
---
--- @
---   isRed Red     = True
---   isRed _       = False
---   isGreen Green = True
---   isGreen _     = False
---   isBlue Blue   = True
---   isBlue _      = False
--- @
---
-mkConstrTests :: [Name] -> Q [Dec]
-mkConstrTests = concat <.> mapM mk 
-  where
-    mk name = do
-      i <- reify name
-      map fromJust . filter isJust <.> mapM mkPredicate $
-        case i of
-          TyConI (DataD _ _ _ cs _) -> cs
-          _ -> []
-
-    mkPredicate (NormalC name ts) = Just <$> mkPredicate' name (length ts)
-    mkPredicate (RecC name ts)   = Just <$> mkPredicate' name (length ts)
-    mkPredicate _                = return Nothing
-
-    mkPredicate' name argc = return $
-      FunD (predName name)
-        [ Clause [ConP name $ replicate argc WildP] (NormalB $ ConE (mkName "True")) []
-        , Clause [WildP] (NormalB $ ConE (mkName "False")) []
-        ]
-
-    predName name = mkName ("is" ++ nameBase name)
-


### PR DESCRIPTION
Hi Steffen,

The current version of the sec package on Hackage still has the dependency on template-haskell 2.4, and so doesn't work with recent GHCs. I often find myself defining several of these SECs in every project I use, so it would be handy to have a package that pre-defines them that works with modern GHCs.

Even without the template haskell dependency issue (I see you liberalised the dependency to any 2.\* version on github), it would be nice to be able to depend on this in packages I don't want to depend on template haskell at all. So I've taken the liberty of splitting the template haskell stuff into a separate package (see: https://github.com/cumber/sec-th).

If you agree, it would be great if you could pull this in and release it on Hackage. If you're no longer interested in maintaining this on Hackage, I'd be happy to take it over.

Cheers,
Ben
